### PR TITLE
Add missing EventStoreException in use block

### DIFF
--- a/src/DBALEventStoreException.php
+++ b/src/DBALEventStoreException.php
@@ -11,6 +11,7 @@
 
 namespace Broadway\EventStore\Dbal;
 
+use Broadway\EventStore\EventStoreException;
 use Doctrine\DBAL\DBALException;
 
 /**


### PR DESCRIPTION
Now it throws a `ClassNotFoundException`:

```
ClassNotFoundException in DBALEventStoreException.php line 19:
Attempted to load class "EventStoreException" from namespace "Broadway\EventStore\Dbal".
Did you forget a "use" statement for "Broadway\EventStore\EventStoreException"?
```

Reproduce: set the $useBinary to `false` in the DBALEventStore [constructor](https://github.com/broadway/event-store-dbal/blob/master/src/DBALEventStore.php#L64)