### PR TITLE
Set binaryUuidConverter as an optional parameter

### DIFF
--- a/src/DBALEventStore.php
+++ b/src/DBALEventStore.php
@@ -62,7 +62,7 @@ class DBALEventStore implements EventStore, EventStoreManagement
         Serializer $metadataSerializer,
         $tableName,
         $useBinary,
-        BinaryUuidConverterInterface $binaryUuidConverter
+        BinaryUuidConverterInterface $binaryUuidConverter = null
     ) {
         $this->connection          = $connection;
         $this->payloadSerializer   = $payloadSerializer;


### PR DESCRIPTION
The constructor of `DBALEventStore` provides [`$useBinary` flag](https://github.com/broadway/event-store-dbal/blob/master/src/DBALEventStore.php#L64-L65) as a parameter. If the parameter is `false`, `$binaryUuidConverter` is not used in the code. I think it will be useful for the non-binary case if the parameter contains a default value as null.

Thanks for the great work!