### PR TITLE
Allow configureTable method use an existing schema

### DIFF
--- a/src/DBALEventStore.php
+++ b/src/DBALEventStore.php
@@ -173,12 +173,12 @@ class DBALEventStore implements EventStore, EventStoreManagement
             return null;
         }
 
-        return $this->configureTable();
+        return $this->configureTable($schema);
     }
 
-    public function configureTable()
+    public function configureTable(Schema $schema = null)
     {
-        $schema = new Schema();
+        $schema = $schema ?: new Schema();
 
         $uuidColumnDefinition = [
             'type'   => 'guid',


### PR DESCRIPTION
It was complicated use this library with Doctrine migrations. 

Allowing to pass a `Schema` instance to `DBALEventStore::configureTable()` method make it easier. 

I set it as nullable to not generate a breaking change.

This is the final result of the migration after this changes:
```php
<?php

declare(strict_types = 1);

namespace DoctrineMigrations;

use Broadway\EventStore\Dbal\DBALEventStore;
use Doctrine\DBAL\Migrations\AbstractMigration;
use Doctrine\DBAL\Schema\Schema;
use Doctrine\ORM\EntityManager;
use Symfony\Component\DependencyInjection\ContainerAwareInterface;
use Symfony\Component\DependencyInjection\ContainerInterface;

/**
 * Auto-generated Migration: Please modify to your needs!
 */
class Version20180102233829 extends AbstractMigration implements ContainerAwareInterface
{

    public function up(Schema $schema)
    {
        $this->eventStore->configureSchema($schema);

        $this->em->flush();
    }


    public function down(Schema $schema)
    {
        $schema->dropTable('events');

        $this->em->flush();
    }

    public function setContainer(ContainerInterface $container = null)
    {
        $this->eventStore = $container->get(DBALEventStore::class);
        $this->em = $container->get('doctrine.orm.entity_manager');
    }

    /** @var EntityManager */
    private $em;

    /** @var DBALEventStore */
    private $eventStore;
}

```