### PR TITLE
[RFC] drop id column

### DIFF
--- a/src/DBALEventStore.php
+++ b/src/DBALEventStore.php
@@ -197,7 +197,6 @@ class DBALEventStore implements EventStore, EventStoreManagement
 
         $table = $schema->createTable($this->tableName);
 
-        $table->addColumn('id', 'integer', ['autoincrement' => true]);
         $table->addColumn('uuid', $uuidColumnDefinition['type'], $uuidColumnDefinition['params']);
         $table->addColumn('playhead', 'integer', ['unsigned' => true]);
         $table->addColumn('payload', 'text');
@@ -205,8 +204,7 @@ class DBALEventStore implements EventStore, EventStoreManagement
         $table->addColumn('recorded_on', 'string', ['length' => 32]);
         $table->addColumn('type', 'string', ['length' => 255]);
 
-        $table->setPrimaryKey(['id']);
-        $table->addUniqueIndex(['uuid', 'playhead']);
+        $table->setPrimaryKey(['uuid', 'playhead']);
 
         return $table;
     }
@@ -281,14 +279,9 @@ class DBALEventStore implements EventStore, EventStoreManagement
     private function prepareVisitEventsStatement(Criteria $criteria)
     {
         list($where, $bindValues, $bindValueTypes) = $this->prepareVisitEventsStatementWhereAndBindValues($criteria);
-        $query                                     = 'SELECT uuid, playhead, metadata, payload, recorded_on
-            FROM ' . $this->tableName . '
-            ' . $where . '
-            ORDER BY id ASC';
+        $query = sprintf('SELECT uuid, playhead, metadata, payload, recorded_on FROM %s %s', $this->tableName, $where);
 
-        $statement = $this->connection->executeQuery($query, $bindValues, $bindValueTypes);
-
-        return $statement;
+        return $this->connection->executeQuery($query, $bindValues, $bindValueTypes);
     }
 
     private function prepareVisitEventsStatementWhereAndBindValues(Criteria $criteria)


### PR DESCRIPTION
fixes #8, see #18 

The `id` has no real usage (https://github.com/broadway/event-store-dbal/issues/18#issuecomment-396228433)

This PR breaks the existing order when visiting events (explained in #8) 