### PR TITLE
Fix return type issue in prepareVisitEventsStatement

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,9 +9,3 @@ parameters:
 			message: "#^Cannot call static method fromBytes\\(\\) on Broadway\\\\UuidGenerator\\\\Converter\\\\BinaryUuidConverterInterface\\|null\\.$#"
 			count: 1
 			path: src/DBALEventStore.php
-
-		-
-			message: "#^Method Broadway\\\\EventStore\\\\Dbal\\\\DBALEventStore\\:\\:prepareVisitEventsStatement\\(\\) should return Doctrine\\\\DBAL\\\\Driver\\\\Statement but returns Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\.$#"
-			count: 1
-			path: src/DBALEventStore.php
-

--- a/src/DBALEventStore.php
+++ b/src/DBALEventStore.php
@@ -28,6 +28,7 @@ use Broadway\Serializer\Serializer;
 use Broadway\UuidGenerator\Converter\BinaryUuidConverterInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Schema\Schema;
@@ -294,7 +295,6 @@ class DBALEventStore implements EventStore, EventStoreManagement
     public function visitEvents(Criteria $criteria, EventVisitor $eventVisitor): void
     {
         $statement = $this->prepareVisitEventsStatement($criteria);
-        $statement->execute();
 
         while ($row = $statement->fetch()) {
             $domainMessage = $this->deserializeEvent($row);
@@ -303,7 +303,7 @@ class DBALEventStore implements EventStore, EventStoreManagement
         }
     }
 
-    private function prepareVisitEventsStatement(Criteria $criteria): Statement
+    private function prepareVisitEventsStatement(Criteria $criteria): ResultStatement
     {
         list($where, $bindValues, $bindValueTypes) = $this->prepareVisitEventsStatementWhereAndBindValues($criteria);
         $query = 'SELECT uuid, playhead, metadata, payload, recorded_on


### PR DESCRIPTION
`DBAL\Connection::executeQuery` has a return type of `ResultStatement` in `doctrine/dbal ^2.8`.
Statement is a child class of `ResultStatement` in `doctrine/dbal ^2.4`.

Forward compatibility layer of `doctrine/dbal 2.13` changes return type of `DBAL\Connection::executeQuery` to `ResultStatement&BaseResult` which specifically removes execute method from the result statement.
The method already executes the statement, so it is not needed explicitly in `visitEvents`.