### PR TITLE
fix failing json_encode issue

### DIFF
--- a/src/DBALEventStore.php
+++ b/src/DBALEventStore.php
@@ -170,11 +170,21 @@ class DBALEventStore implements EventStore, EventStoreManagement
 
     private function insertMessage(Connection $connection, DomainMessage $domainMessage): void
     {
+        $metadata = json_encode($this->metadataSerializer->serialize($domainMessage->getMetadata()));
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException('unable to encode `metadata`');
+        }
+
+        $payload = json_encode($this->payloadSerializer->serialize($domainMessage->getPayload()));
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException('unable to encode `payload`');
+        }
+
         $data = [
             'uuid' => $this->convertIdentifierToStorageValue((string) $domainMessage->getId()),
             'playhead' => $domainMessage->getPlayhead(),
-            'metadata' => json_encode($this->metadataSerializer->serialize($domainMessage->getMetadata())),
-            'payload' => json_encode($this->payloadSerializer->serialize($domainMessage->getPayload())),
+            'metadata' => $metadata,
+            'payload' => $payload,
             'recorded_on' => $domainMessage->getRecordedOn()->toString(),
             'type' => $domainMessage->getType(),
         ];


### PR DESCRIPTION
Today a not UTF-8 string got from a CSV entered in an event and when the sezialied event was json_encoded the event store inserted a record in the event table with an empty payload field.

This PR is just a suggestion to explain the issue and how it could be resolved.